### PR TITLE
Update the announcement get function

### DIFF
--- a/uma_gacha/__init__.py
+++ b/uma_gacha/__init__.py
@@ -31,19 +31,19 @@ async def uma_gacha_char_jing(bot, ev):
     await bot.send(ev, msg, at_sender=True)
 
 # 育成卡单抽
-@sv.on_fullmatch(('育成卡单抽', '支援卡单抽'), only_to_me=True)
+@sv.on_fullmatch(('育成卡单抽', '支援卡单抽','s卡单抽','S卡单抽'), only_to_me=True)
 async def uma_gacha_card_one(bot, ev):
     msg = await pretty_draw(1, 'card')
     await bot.send(ev, msg, at_sender=True)
 
 # 育成卡十连
-@sv.on_fullmatch(('育成卡十连', '支援卡十连'), only_to_me=True)
+@sv.on_fullmatch(('育成卡十连', '支援卡十连','s卡十连','S卡十连'), only_to_me=True)
 async def uma_gacha_card_ten(bot, ev):
     msg = await pretty_draw(10, 'card')
     await bot.send(ev, msg, at_sender=True)
 
 # 育成卡井
-@sv.on_fullmatch(('育成卡井', '育成卡一井', '支援卡井', '支援卡一井'), only_to_me=True)
+@sv.on_fullmatch(('育成卡井', '育成卡一井', '支援卡井', '支援卡一井','s卡井','s卡一井','S卡井','S卡一井'), only_to_me=True)
 async def uma_gacha_card_jing(bot, ev):
     msg = await pretty_draw(200, 'card')
     await bot.send(ev, msg, at_sender=True)

--- a/uma_gacha/announcement.py
+++ b/uma_gacha/announcement.py
@@ -64,19 +64,14 @@ class PrettyAnnouncement:
             async with session.get(pretty_url, timeout=7) as res:
                 soup = BeautifulSoup(await res.text(), 'lxml')
                 divs = soup.find('div', {'id': 'mw-content-text'}).find('div').find_all('div')
+                re_str = ".*&.*\d+"
                 for div in divs:
                     a = div.find('a')
                     try:
                         title = a['title']
                     except (KeyError, TypeError):
                         continue
-                    if title.find('支援卡卡池') != -1:
-                        url = a['href']
-                        break
-                    elif title.find('支援卡登场') != -1:
-                        url = a['href']
-                        break
-                    elif title.find('新团队卡') != -1:
+                    if re.search(re_str,title) != None:
                         url = a['href']
                         break
             # async with session.get(f'https://wiki.biligame.com/{url}', timeout=7) as res:


### PR DESCRIPTION
使用正则表达式来分辨 BWiki 的卡池链接文本，观察发现现在文本不论怎么改变都会有 **&** 符号以及数字形式的卡池日期 **yyyymmdd**，所以改变了一下查询 url 的方法，本地测试成功（删除旧卡池信息后重新更新正确获取当前卡池信息）。

Signed-off-by: BossWangST <bosswang1226@gmail.com>